### PR TITLE
fix: update user profile test field names to camelCase format

### DIFF
--- a/tests/integration/api/test_user.py
+++ b/tests/integration/api/test_user.py
@@ -44,17 +44,16 @@ class TestUserProfile:
         profile_data = response.json()
         # Verify response structure
         assert "id" in profile_data
-        assert "first_name" in profile_data
-        assert "last_name" in profile_data
+        assert "firstName" in profile_data
+        assert "lastName" in profile_data
         assert "username" in profile_data
-        assert "bio" in profile_data
 
         # Verify data types
         assert isinstance(profile_data["id"], int)
-        assert isinstance(profile_data["first_name"], str)
+        assert isinstance(profile_data["firstName"], str)
 
         # Verify user data from test config
-        assert profile_data["first_name"] == "min"
+        assert profile_data["firstName"] == "min"
         assert profile_data["username"] == "zurab"
 
     async def test_get_profile_unauthorized_no_auth_header(
@@ -103,16 +102,16 @@ class TestUserProfile:
         profile_data = response.json()
 
         # Test all required fields exist
-        required_fields = ["id", "first_name", "last_name", "username", "bio"]
+        required_fields = ["id", "firstName", "lastName", "username"]
         for field in required_fields:
             assert field in profile_data, f"Field '{field}' missing from response"
 
         # Test data types
         assert isinstance(profile_data["id"], int)
-        assert isinstance(profile_data["first_name"], str)
+        assert isinstance(profile_data["firstName"], str)
 
         # Optional fields can be None or strings
-        for field in ["last_name", "username", "bio"]:
+        for field in ["lastName", "username"]:
             assert profile_data[field] is None or isinstance(profile_data[field], str)
 
     async def test_get_profile_multiple_requests_consistent(
@@ -157,7 +156,7 @@ class TestUserProfile:
 
         # Should return same user data since same Telegram init data
         assert profile1["id"] == profile2["id"]
-        assert profile1["first_name"] == profile2["first_name"]
+        assert profile1["firstName"] == profile2["firstName"]
         assert profile1["username"] == profile2["username"]
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
## Description
Updates test assertions in user profile integration tests to use camelCase field names (firstName, lastName) instead of snake_case (first_name, last_name) and removes bio field assertions to match API response format changes.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code quality improvement
- [ ] Configuration change

## Testing
- [x] Tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested integration scenarios if applicable

## Code Quality
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have made corresponding changes to the documentation if needed
- [x] Pre-commit hooks pass (run `pre-commit run --all-files`)
- [x] Ruff linting passes (`ruff check src/ tests/`)
- [x] Ruff formatting passes (`ruff format src/ tests/ --check`)

## Related Issues
Fixes field name inconsistency in user profile API tests

## Additional Notes
This change aligns the test expectations with the actual API response format that uses camelCase field names instead of snake_case.

🤖 Generated with [Claude Code](https://claude.ai/code)