### PR TITLE
🐞 fix(db): use timezone-aware timestamps in user model

### DIFF
--- a/src/infrastructure/db/migrations/versions/2026_01_24_1059-80231256407c_add_user_timestamps.py
+++ b/src/infrastructure/db/migrations/versions/2026_01_24_1059-80231256407c_add_user_timestamps.py
@@ -24,7 +24,7 @@ def upgrade() -> None:
         "users",
         sa.Column(
             "created_at",
-            sa.DateTime(),
+            sa.DateTime(timezone=True),
             server_default=sa.func.now(),
             nullable=False,
         ),
@@ -33,7 +33,7 @@ def upgrade() -> None:
         "users",
         sa.Column(
             "updated_at",
-            sa.DateTime(),
+            sa.DateTime(timezone=True),
             server_default=sa.func.now(),
             nullable=False,
         ),
@@ -42,7 +42,7 @@ def upgrade() -> None:
         "users",
         sa.Column(
             "last_login_at",
-            sa.DateTime(),
+            sa.DateTime(timezone=True),
             server_default=sa.func.now(),
             nullable=False,
         ),

--- a/src/infrastructure/db/models/user.py
+++ b/src/infrastructure/db/models/user.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-from sqlalchemy import func
+from sqlalchemy import TIMESTAMP, func
 from sqlalchemy.orm import Mapped, mapped_column
 
 from src.domain.user.entity import User
@@ -20,11 +20,15 @@ class UserModel(BaseORMModel):
         UsernameType, nullable=True, unique=False
     )
     bio: Mapped[Bio | None] = mapped_column(BioType, nullable=True)
-    created_at: Mapped[datetime] = mapped_column(server_default=func.now())
-    updated_at: Mapped[datetime] = mapped_column(
-        server_default=func.now(), onupdate=func.now()
+    created_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True), server_default=func.now()
     )
-    last_login_at: Mapped[datetime] = mapped_column(server_default=func.now())
+    updated_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True), server_default=func.now(), onupdate=func.now()
+    )
+    last_login_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True), server_default=func.now()
+    )
 
     def to_domain(self) -> User:
         return User(

--- a/src/infrastructure/db/repos/user.py
+++ b/src/infrastructure/db/repos/user.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from typing import Unpack
 
 from sqlalchemy import select, update
@@ -50,7 +50,7 @@ class UserRepositoryImpl(UserRepository, BaseSQLAlchemyRepo):
                 username=fields["username"],
                 first_name=fields["first_name"],
                 last_name=fields["last_name"],
-                last_login_at=datetime.now(timezone.utc),
+                last_login_at=datetime.now(UTC),
             )
             .returning(UserModel)
         )

--- a/tests/unit/application/auth/test_tg.py
+++ b/tests/unit/application/auth/test_tg.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from unittest.mock import AsyncMock, Mock
 
 import pytest
@@ -54,7 +54,7 @@ class TestAuthTgInteractor:
 
     @pytest.fixture
     def sample_user(self) -> User:
-        now = datetime.now(timezone.utc)
+        now = datetime.now(UTC)
         return User(
             id=UserId(456),
             username=Username("username"),

--- a/tests/unit/application/user/test_create.py
+++ b/tests/unit/application/user/test_create.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from unittest.mock import AsyncMock, Mock
 
 import pytest
@@ -62,7 +62,7 @@ class TestCreateUserInteractor:
 
     @pytest.fixture
     def sample_user(self) -> User:
-        now = datetime.now(timezone.utc)
+        now = datetime.now(UTC)
         return User(
             id=UserId(456),
             username=Username("testuser"),
@@ -76,7 +76,7 @@ class TestCreateUserInteractor:
 
     @pytest.fixture
     def sample_user_no_optional(self) -> User:
-        now = datetime.now(timezone.utc)
+        now = datetime.now(UTC)
         return User(
             id=UserId(789),
             username=None,
@@ -305,7 +305,7 @@ class TestCreateUserInteractor:
             photo_url="http://example.com/photo.jpg",
         )
 
-        now = datetime.now(timezone.utc)
+        now = datetime.now(UTC)
         created_user = User(
             id=UserId(user_id_value),
             username=Username("testuser"),

--- a/tests/unit/application/user/test_get_me.py
+++ b/tests/unit/application/user/test_get_me.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from unittest.mock import AsyncMock, Mock
 
 import pytest
@@ -32,7 +32,7 @@ class TestGetUserProfileInteractor:
 
     @pytest.fixture
     def sample_user_with_all_fields(self) -> User:
-        now = datetime.now(timezone.utc)
+        now = datetime.now(UTC)
         return User(
             id=UserId(456),
             username=Username("testuser"),
@@ -46,7 +46,7 @@ class TestGetUserProfileInteractor:
 
     @pytest.fixture
     def sample_user_with_optional_none(self) -> User:
-        now = datetime.now(timezone.utc)
+        now = datetime.now(UTC)
         return User(
             id=UserId(456),
             username=None,
@@ -138,7 +138,7 @@ class TestGetUserProfileInteractor:
     ):
         input_dto = GetUserProfileInputDTO(user_id=UserId(user_id_value))
 
-        now = datetime.now(timezone.utc)
+        now = datetime.now(UTC)
         user = User(
             id=UserId(user_id_value),
             username=Username("testuser"),

--- a/tests/unit/infrastructure/test_config.py
+++ b/tests/unit/infrastructure/test_config.py
@@ -279,7 +279,10 @@ class TestLoadConfig:
                 "algorithm": "HS256",
                 "access_token_expire_minutes": 30,
             },
-            "telegram": {"bot_token": "123456789:ABCdefGHIjklMNOpqrsTUVwxyz", "admin_ids": [123456789]},
+            "telegram": {
+                "bot_token": "123456789:ABCdefGHIjklMNOpqrsTUVwxyz",
+                "admin_ids": [123456789],
+            },
         }
 
         with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
@@ -317,7 +320,10 @@ class TestLoadConfig:
                 "algorithm": "HS256",
                 "access_token_expire_minutes": 30,
             },
-            "telegram": {"bot_token": "123456789:ABCdefGHIjklMNOpqrsTUVwxyz", "admin_ids": [123456789]},
+            "telegram": {
+                "bot_token": "123456789:ABCdefGHIjklMNOpqrsTUVwxyz",
+                "admin_ids": [123456789],
+            },
         }
 
         yaml_content = yaml.dump(config_data)
@@ -412,7 +418,10 @@ class TestLoadConfig:
                 "algorithm": "HS256",
                 "access_token_expire_minutes": 30,
             },
-            "telegram": {"bot_token": "123456789:ABCdefGHIjklMNOpqrsTUVwxyz", "admin_ids": [123456789]},
+            "telegram": {
+                "bot_token": "123456789:ABCdefGHIjklMNOpqrsTUVwxyz",
+                "admin_ids": [123456789],
+            },
             "extra_config": "ignored",
         }
 
@@ -442,7 +451,10 @@ class TestLoadConfig:
                 "algorithm": "HS256",
                 "access_token_expire_minutes": 30,
             },
-            "telegram": {"bot_token": "123456789:ABCdefGHIjklMNOpqrsTUVwxyz", "admin_ids": [123456789]},
+            "telegram": {
+                "bot_token": "123456789:ABCdefGHIjklMNOpqrsTUVwxyz",
+                "admin_ids": [123456789],
+            },
         }
 
         yaml_content = yaml.dump(config_data)
@@ -467,7 +479,10 @@ class TestLoadConfig:
                 "algorithm": "HS256",
                 "access_token_expire_minutes": 30,
             },
-            "telegram": {"bot_token": "123456789:ABCdefGHIjklMNOpqrsTUVwxyz", "admin_ids": [123456789]},
+            "telegram": {
+                "bot_token": "123456789:ABCdefGHIjklMNOpqrsTUVwxyz",
+                "admin_ids": [123456789],
+            },
         }
 
         yaml_content = yaml.dump(config_data)

--- a/tests/utils/model_factories/user.py
+++ b/tests/utils/model_factories/user.py
@@ -1,5 +1,5 @@
 from collections.abc import Awaitable, Callable
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
 import factory
 import pytest
@@ -18,9 +18,9 @@ class UserModelFactory(BaseFactory):
     last_name = factory.Faker("last_name")
     username = factory.Faker("name")
     bio = factory.Faker("sentence")
-    created_at = factory.LazyFunction(lambda: datetime.now(timezone.utc))
-    updated_at = factory.LazyFunction(lambda: datetime.now(timezone.utc))
-    last_login_at = factory.LazyFunction(lambda: datetime.now(timezone.utc))
+    created_at = factory.LazyFunction(lambda: datetime.now(UTC))
+    updated_at = factory.LazyFunction(lambda: datetime.now(UTC))
+    last_login_at = factory.LazyFunction(lambda: datetime.now(UTC))
 
 
 @pytest.fixture(scope="function")


### PR DESCRIPTION
## Summary

- Add `timezone=True` to DateTime columns in migration for proper timezone-aware storage
- Use `TIMESTAMP(timezone=True)` in UserModel instead of bare DateTime
- Modernize `datetime.timezone.utc` to `datetime.UTC` constant (Python 3.11+)

## Background

The user timestamp fields (`created_at`, `updated_at`, `last_login_at`) were added in #53 but used timezone-naive DateTime columns. This can cause issues when comparing timestamps or when the database/application servers are in different timezones.

This fix ensures all timestamps are stored with timezone information, preventing potential bugs with datetime comparisons and making the system more robust across different deployment environments.

## Changes

| File | Change |
|------|--------|
| `migrations/.../add_user_timestamps.py` | `DateTime()` → `DateTime(timezone=True)` |
| `models/user.py` | Use `TIMESTAMP(timezone=True)` explicitly |
| `repos/user.py` | `timezone.utc` → `UTC` |
| Tests & factories | Same `UTC` modernization |

## Checklist

- [x] Migration updated with timezone-aware columns
- [x] Model uses explicit TIMESTAMP type with timezone
- [x] Repository uses modern UTC constant
- [x] All tests updated and passing (168 passed)
- [x] Ruff format/lint passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)