### PR TITLE
✨ feat(sentry): add optional Sentry integration for bot and API

### DIFF
--- a/config-example.yaml
+++ b/config-example.yaml
@@ -23,3 +23,9 @@ auth:
 
 log:
   level: "INFO"
+
+# sentry:
+#   dsn: "https://examplePublicKey@o0.ingest.sentry.io/0"
+#   environment: "development"
+#   traces_sample_rate: 1.0
+#   profiles_sample_rate: 1.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
     "typer>=0.15.0",
     "uvicorn>=0.35.0",
     "gunicorn>=23.0.0",
+    "sentry-sdk[litestar]>=2.0.0",
     "pytest-timeout>=2.4.0",
     "pytest-sugar>=1.1.1",
     "pytest-randomly>=3.16.0",

--- a/src/infrastructure/config.py
+++ b/src/infrastructure/config.py
@@ -43,10 +43,18 @@ class TelegramConfig(BaseModel):
     tg_init_data: str = "for-auth-endpoint-tests"
 
 
+class SentryConfig(BaseModel):
+    dsn: str
+    environment: str = "production"
+    traces_sample_rate: float = 1.0
+    profiles_sample_rate: float = 1.0
+
+
 class Config(BaseModel):
     postgres: PostgresConfig
     auth: AuthConfig
     telegram: TelegramConfig
+    sentry: SentryConfig | None = None
 
 
 def load_config(file_name: str = "config.yaml") -> Config:

--- a/src/infrastructure/config.py
+++ b/src/infrastructure/config.py
@@ -45,9 +45,16 @@ class TelegramConfig(BaseModel):
 
 class SentryConfig(BaseModel):
     dsn: str
-    environment: str = "production"
+    environment: str = "development"  # development, production
     traces_sample_rate: float = 1.0
     profiles_sample_rate: float = 1.0
+
+    @field_validator("traces_sample_rate", "profiles_sample_rate")
+    @classmethod
+    def validate_sample_rate(cls, v: float) -> float:
+        if not 0.0 <= v <= 1.0:
+            raise ValueError("Sample rate must be between 0.0 and 1.0")
+        return v
 
 
 class Config(BaseModel):

--- a/src/infrastructure/sentry.py
+++ b/src/infrastructure/sentry.py
@@ -11,10 +11,15 @@ def init_sentry(config: Config) -> None:
 
     import sentry_sdk  # noqa: PLC0415
 
-    sentry_sdk.init(
-        dsn=config.sentry.dsn,
-        environment=config.sentry.environment,
-        traces_sample_rate=config.sentry.traces_sample_rate,
-        profiles_sample_rate=config.sentry.profiles_sample_rate,
-    )
-    logger.info("Sentry initialized for environment: %s", config.sentry.environment)
+    try:
+        sentry_sdk.init(
+            dsn=config.sentry.dsn,
+            environment=config.sentry.environment,
+            traces_sample_rate=config.sentry.traces_sample_rate,
+            profiles_sample_rate=config.sentry.profiles_sample_rate,
+        )
+        logger.info("Sentry initialized for environment: %s", config.sentry.environment)
+    except Exception:
+        logger.warning(
+            "Failed to initialize Sentry; continuing without it", exc_info=True
+        )

--- a/src/infrastructure/sentry.py
+++ b/src/infrastructure/sentry.py
@@ -1,0 +1,20 @@
+import logging
+
+from src.infrastructure.config import Config
+
+logger = logging.getLogger(__name__)
+
+
+def init_sentry(config: Config) -> None:
+    if config.sentry is None:
+        return
+
+    import sentry_sdk  # noqa: PLC0415
+
+    sentry_sdk.init(
+        dsn=config.sentry.dsn,
+        environment=config.sentry.environment,
+        traces_sample_rate=config.sentry.traces_sample_rate,
+        profiles_sample_rate=config.sentry.profiles_sample_rate,
+    )
+    logger.info("Sentry initialized for environment: %s", config.sentry.environment)

--- a/src/presentation/api/app.py
+++ b/src/presentation/api/app.py
@@ -13,6 +13,7 @@ from src.infrastructure.config import Config, load_config
 from src.infrastructure.di import interactor_providers
 from src.infrastructure.di.auth import AuthProvider
 from src.infrastructure.di.db import DBProvider
+from src.infrastructure.sentry import init_sentry
 
 from .exception import (
     custom_exception_handler,
@@ -53,6 +54,7 @@ def prepare_app(auth_service: AuthService) -> Litestar:
 
 def create_app() -> Litestar:
     config = load_config()
+    init_sentry(config)
 
     auth_service: AuthService = AuthServiceImpl(config)
     app = prepare_app(auth_service)

--- a/src/presentation/bot/main.py
+++ b/src/presentation/bot/main.py
@@ -18,6 +18,7 @@ from src.infrastructure.di import (
     interactor_providers,
 )
 from src.infrastructure.i18n import DEFAULT_LANGUAGE, TranslatorRunner
+from src.infrastructure.sentry import init_sentry
 from src.presentation.bot.middleware.user_and_locale import UserAndLocaleMiddleware
 from src.presentation.bot.routers import setup_routers
 
@@ -36,6 +37,8 @@ async def notify_admins_on_startup(
 
 async def main() -> None:
     config = load_config()
+    init_sentry(config)
+
     bot = Bot(
         token=config.telegram.bot_token,
         default=DefaultBotProperties(parse_mode=ParseMode.HTML),

--- a/tests/unit/infrastructure/test_config.py
+++ b/tests/unit/infrastructure/test_config.py
@@ -287,9 +287,20 @@ class TestSentryConfig:
     def test_valid_config(self):
         config = SentryConfig(dsn="https://key@sentry.io/123")
         assert config.dsn == "https://key@sentry.io/123"
-        assert config.environment == "production"
+        assert config.environment == "development"
         assert config.traces_sample_rate == 1.0
         assert config.profiles_sample_rate == 1.0
+
+    @pytest.mark.parametrize(
+        "rate",
+        [-0.1, 1.1, 2.0, -1.0],
+    )
+    def test_invalid_sample_rate(self, rate):
+        with pytest.raises(ValidationError):
+            SentryConfig(dsn="https://key@sentry.io/123", traces_sample_rate=rate)
+
+        with pytest.raises(ValidationError):
+            SentryConfig(dsn="https://key@sentry.io/123", profiles_sample_rate=rate)
 
     def test_custom_values(self):
         config = SentryConfig(

--- a/tests/unit/infrastructure/test_config.py
+++ b/tests/unit/infrastructure/test_config.py
@@ -10,6 +10,7 @@ from src.infrastructure.config import (
     AuthConfig,
     Config,
     PostgresConfig,
+    SentryConfig,
     TelegramConfig,
     load_config,
 )
@@ -282,6 +283,30 @@ class TestTelegramConfig:
         assert config.bot_token == expected
 
 
+class TestSentryConfig:
+    def test_valid_config(self):
+        config = SentryConfig(dsn="https://key@sentry.io/123")
+        assert config.dsn == "https://key@sentry.io/123"
+        assert config.environment == "production"
+        assert config.traces_sample_rate == 1.0
+        assert config.profiles_sample_rate == 1.0
+
+    def test_custom_values(self):
+        config = SentryConfig(
+            dsn="https://key@sentry.io/123",
+            environment="staging",
+            traces_sample_rate=0.5,
+            profiles_sample_rate=0.25,
+        )
+        assert config.environment == "staging"
+        assert config.traces_sample_rate == 0.5
+        assert config.profiles_sample_rate == 0.25
+
+    def test_dsn_required(self):
+        with pytest.raises(ValidationError):
+            SentryConfig()
+
+
 class TestConfig:
     def test_valid_config(self):
         postgres_config = PostgresConfig(
@@ -304,6 +329,32 @@ class TestConfig:
         assert config.postgres == postgres_config
         assert config.auth == auth_config
         assert config.telegram == telegram_config
+
+    def test_config_without_sentry(self):
+        config = Config(
+            postgres=PostgresConfig(
+                host="localhost", port=5432, user="u", password="p", db="d"
+            ),
+            auth=AuthConfig(
+                secret_key="s", algorithm="HS256", access_token_expire_minutes=30
+            ),
+            telegram=TelegramConfig(bot_token="t", admin_ids=[1], bot_username="b"),
+        )
+        assert config.sentry is None
+
+    def test_config_with_sentry(self):
+        config = Config(
+            postgres=PostgresConfig(
+                host="localhost", port=5432, user="u", password="p", db="d"
+            ),
+            auth=AuthConfig(
+                secret_key="s", algorithm="HS256", access_token_expire_minutes=30
+            ),
+            telegram=TelegramConfig(bot_token="t", admin_ids=[1], bot_username="b"),
+            sentry=SentryConfig(dsn="https://key@sentry.io/123"),
+        )
+        assert config.sentry is not None
+        assert config.sentry.dsn == "https://key@sentry.io/123"
 
     @pytest.mark.parametrize(
         "postgres,should_raise",

--- a/tests/unit/infrastructure/test_sentry.py
+++ b/tests/unit/infrastructure/test_sentry.py
@@ -1,0 +1,58 @@
+from unittest.mock import patch
+
+from src.infrastructure.config import (
+    AuthConfig,
+    Config,
+    PostgresConfig,
+    SentryConfig,
+    TelegramConfig,
+)
+from src.infrastructure.sentry import init_sentry
+
+
+def _make_config(sentry: SentryConfig | None = None) -> Config:
+    return Config(
+        postgres=PostgresConfig(host="h", port=5432, user="u", password="p", db="d"),
+        auth=AuthConfig(
+            secret_key="s", algorithm="HS256", access_token_expire_minutes=30
+        ),
+        telegram=TelegramConfig(bot_token="t", admin_ids=[1], bot_username="b"),
+        sentry=sentry,
+    )
+
+
+class TestInitSentry:
+    def test_no_sentry_config_skips_init(self):
+        config = _make_config(sentry=None)
+        with patch("sentry_sdk.init") as mock_init:
+            init_sentry(config)
+            mock_init.assert_not_called()
+
+    def test_sentry_config_calls_init(self):
+        sentry_cfg = SentryConfig(
+            dsn="https://key@sentry.io/123",
+            environment="test",
+            traces_sample_rate=0.5,
+            profiles_sample_rate=0.25,
+        )
+        config = _make_config(sentry=sentry_cfg)
+        with patch("sentry_sdk.init") as mock_init:
+            init_sentry(config)
+            mock_init.assert_called_once_with(
+                dsn="https://key@sentry.io/123",
+                environment="test",
+                traces_sample_rate=0.5,
+                profiles_sample_rate=0.25,
+            )
+
+    def test_sentry_config_default_values(self):
+        sentry_cfg = SentryConfig(dsn="https://key@sentry.io/123")
+        config = _make_config(sentry=sentry_cfg)
+        with patch("sentry_sdk.init") as mock_init:
+            init_sentry(config)
+            mock_init.assert_called_once_with(
+                dsn="https://key@sentry.io/123",
+                environment="production",
+                traces_sample_rate=1.0,
+                profiles_sample_rate=1.0,
+            )

--- a/tests/unit/infrastructure/test_sentry.py
+++ b/tests/unit/infrastructure/test_sentry.py
@@ -52,7 +52,13 @@ class TestInitSentry:
             init_sentry(config)
             mock_init.assert_called_once_with(
                 dsn="https://key@sentry.io/123",
-                environment="production",
+                environment="development",
                 traces_sample_rate=1.0,
                 profiles_sample_rate=1.0,
             )
+
+    def test_sentry_init_failure_continues(self):
+        sentry_cfg = SentryConfig(dsn="https://key@sentry.io/123")
+        config = _make_config(sentry=sentry_cfg)
+        with patch("sentry_sdk.init", side_effect=Exception("connection failed")):
+            init_sentry(config)

--- a/uv.lock
+++ b/uv.lock
@@ -155,6 +155,7 @@ dependencies = [
     { name = "python-jose" },
     { name = "pyyaml" },
     { name = "ruff" },
+    { name = "sentry-sdk", extra = ["litestar"] },
     { name = "sqlalchemy" },
     { name = "ty" },
     { name = "typer" },
@@ -191,6 +192,7 @@ requires-dist = [
     { name = "python-jose", specifier = "~=3.4.0" },
     { name = "pyyaml", specifier = ">=6.0.2" },
     { name = "ruff", specifier = ">=0.12.5" },
+    { name = "sentry-sdk", extras = ["litestar"], specifier = ">=2.0.0" },
     { name = "sqlalchemy", specifier = ">=2.0.41" },
     { name = "ty", specifier = ">=0.0.1a16" },
     { name = "typer", specifier = ">=0.15.0" },
@@ -1157,6 +1159,24 @@ wheels = [
 ]
 
 [[package]]
+name = "sentry-sdk"
+version = "2.57.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4f/87/46c0406d8b5ddd026f73adaf5ab75ce144219c41a4830b52df4b9ab55f7f/sentry_sdk-2.57.0.tar.gz", hash = "sha256:4be8d1e71c32fb27f79c577a337ac8912137bba4bcbc64a4ec1da4d6d8dc5199", size = 435288, upload-time = "2026-03-31T09:39:29.264Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c9/64/982e07b93219cb52e1cca5d272cb579e2f3eb001956c9e7a9a6d106c9473/sentry_sdk-2.57.0-py2.py3-none-any.whl", hash = "sha256:812c8bf5ff3d2f0e89c82f5ce80ab3a6423e102729c4706af7413fd1eb480585", size = 456489, upload-time = "2026-03-31T09:39:27.524Z" },
+]
+
+[package.optional-dependencies]
+litestar = [
+    { name = "litestar" },
+]
+
+[[package]]
 name = "shellingham"
 version = "1.5.4"
 source = { registry = "https://pypi.org/simple" }
@@ -1281,6 +1301,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/95/32/1a225d6164441be760d75c2c42e2780dc0873fe382da3e98a2e1e48361e5/tzdata-2025.2.tar.gz", hash = "sha256:b60a638fcc0daffadf82fe0f57e53d06bdec2f36c4df66280ae79bce6bd6f2b9", size = 196380, upload-time = "2025-03-23T13:54:43.652Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5c/23/c7abc0ca0a1526a0774eca151daeb8de62ec457e77262b66b359c3c7679e/tzdata-2025.2-py2.py3-none-any.whl", hash = "sha256:1a403fada01ff9221ca8044d701868fa132215d84beb92242d9acd2147f667a8", size = 347839, upload-time = "2025-03-23T13:54:41.845Z" },
+]
+
+[[package]]
+name = "urllib3"
+version = "2.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
# Pull Request

## Description
Add optional Sentry error tracking to both the Litestar API and aiogram bot entry points. If no `sentry` section is present in the YAML config, the app runs exactly as before.

**Changes:**
- `SentryConfig` Pydantic model with DSN, environment, and sample rate fields
- `init_sentry()` helper in `src/infrastructure/sentry.py`
- Sentry initialization in both API (`create_app`) and bot (`main`) startup paths
- `sentry-sdk[litestar]>=2.0.0` dependency (aiogram integration is auto-discovered)
- Commented-out sentry section in `config-example.yaml`

## Type of Change
- [x] New feature (non-breaking change which adds functionality)
- [x] Configuration change

## Testing
- [x] Tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Code Quality
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have made corresponding changes to the documentation if needed
- [x] Pre-commit hooks pass (run `pre-commit run --all-files`)
- [x] Ruff linting passes (`ruff check src/ tests/`)
- [x] Ruff formatting passes (`ruff format src/ tests/ --check`)

## Additional Notes
- Framework integrations (LitestarIntegration, AiogramIntegration) are auto-discovered by sentry-sdk v2 — no explicit integration setup needed
- The `import sentry_sdk` is inside `init_sentry()` body so it only executes when Sentry is actually configured
- All 207 unit tests pass; the coverage threshold failure (55%) is pre-existing (integration tests require test DB)

---

**Checklist for Reviewers:**
- [ ] Code follows project conventions and style guidelines
- [ ] Changes are well-tested with appropriate test coverage
- [ ] Documentation is updated if necessary
- [ ] Security implications have been considered
- [ ] Performance implications have been considered

🤖 Generated with [Claude Code](https://claude.com/claude-code)