### PR TITLE
🐛 fix(load-test): use pre-instantiated DI providers

### DIFF
--- a/src/presentation/load_test/runner.py
+++ b/src/presentation/load_test/runner.py
@@ -49,10 +49,6 @@ async def setup_dispatcher(config: Config) -> tuple[Dispatcher, Bot]:
         session=NoOpSession(),
     )
 
-    interactor_provider_instances = [
-        interactor() for interactor in interactor_providers
-    ]
-
     dp = Dispatcher(config=config)
     main_router = setup_routers()
     dp.include_router(main_router)
@@ -61,7 +57,7 @@ async def setup_dispatcher(config: Config) -> tuple[Dispatcher, Bot]:
         AuthProvider(),
         DBProvider(),
         I18nProvider(),
-        *interactor_provider_instances,
+        *interactor_providers,
         context={Config: config},
     )
     setup_dishka(container=container, router=dp)


### PR DESCRIPTION
## Description

The load test runner was still manually instantiating interactor providers via a list comprehension, which was missed during the DI refactor in 9c86fb3. This fix removes the redundant instantiation and passes `interactor_providers` directly, aligning with the centralized provider setup used in the bot, API, and tests.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Testing
- [x] I have performed a self-review of my own code
- [x] Pre-commit hooks pass

## Code Quality
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Pre-commit hooks pass (run `pre-commit run --all-files`)
- [x] Ruff linting passes (`ruff check src/ tests/`)
- [x] Ruff formatting passes (`ruff format src/ tests/ --check`)

## Related Issues
Follow-up fix for #79

## Additional Notes
The `interactor_providers` list in `src/infrastructure/di/interactors/__init__.py` was refactored to contain pre-instantiated provider instances. The load test runner was the only consumer that still called `interactor()` on each item, which would fail at runtime since they're already instances, not classes.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)