### PR TITLE
♻️ refactor(ci): post PR reviews as inline threaded comments

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -9,6 +9,7 @@
       "Bash(git stash *)",
       "Bash(git fetch *)",
       "Bash(git pull *)",
+      "Bash(git checkout -b *)",
 
       "Bash(gh issue *)",
       "Bash(gh pr *)",

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
+      pull-requests: write
       issues: read
       id-token: write
     
@@ -37,18 +37,73 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |
-            Please review this pull request and provide feedback on:
-            - Code quality and best practices
-            - Potential bugs or issues
-            - Performance considerations
-            - Security concerns
-            - Test coverage
-            
-            Use the repository's CLAUDE.md for guidance on style and conventions. Be constructive and helpful in your feedback.
+            Perform a thorough code review for this PR. PR context (title, body, diff, changed files)
+            is already available to you — do not fetch it again. Follow CLAUDE.md for style/conventions.
 
-            Use `gh pr comment` with your Bash tool to leave your review as a comment on the PR.
-          
+            ## Review focus
+            1. **Bugs & edge cases** — logic errors, unhandled exceptions, race conditions, off-by-one
+            2. **Security** — injection, auth bypass, sensitive data exposure, insecure dependencies
+            3. **Performance** — N+1 queries, blocking I/O, unnecessary re-computation, memory leaks
+            4. **Code quality** — naming, duplication, complexity, consistency with existing patterns
+            5. **Tests** — coverage of new logic, missing edge cases, weak assertions
+            6. **Breaking changes** — API contracts, DB migrations, backward compatibility
+            7. **Documentation** — docstrings, README, changelog if needed
+
+            ## Inline comment format
+            Each comment targets a specific line in the **new** file version with:
+            - `path` — repo-relative path
+            - `line` — line number on the RIGHT side of the diff
+            - `side` — `"RIGHT"`
+            - `body` — starts with a severity tag, then a brief explanation and (when useful) a concrete fix in a fenced code block:
+              - 🔴 `[CRITICAL]` — must be fixed before merge
+              - 🟡 `[SUGGESTION]` — improvement, not blocking
+              - 🔵 `[QUESTION]` — needs clarification from author
+
+            ## Submitting the review
+            Post **one** review (never a standalone PR comment, never multiple reviews) with all inline
+            comments plus a summary body. Use this exact call:
+
+            ```bash
+            gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews \
+              --method POST \
+              --input - <<'EOF'
+            {
+              "commit_id": "${{ github.event.pull_request.head.sha }}",
+              "body": "<summary, see below>",
+              "event": "<REQUEST_CHANGES | APPROVE | COMMENT>",
+              "comments": [
+                { "path": "relative/path.py", "line": 42, "side": "RIGHT", "body": "🔴 [CRITICAL] ..." }
+              ]
+            }
+            EOF
+            ```
+
+            **Event rule:**
+            - `REQUEST_CHANGES` — at least one 🔴 CRITICAL issue
+            - `APPROVE` — nothing found worth commenting on
+            - `COMMENT` — only 🟡 suggestions or 🔵 questions
+
+            ## Summary body structure
+            ```
+            ## 📋 PR Review — {PR title}
+
+            ### 🔴 Critical Issues ({N})
+            - `path/to/file.py:42` — short description
+
+            ### 🟡 Suggestions ({N})
+            - `path/to/file.py:17` — short description
+
+            ### 🔵 Questions ({N})
+            - Question for the author
+
+            ### ✅ What's done well
+            - Positive observations
+
+            ---
+            ### Verdict: REQUEST_CHANGES | APPROVE | NEEDS DISCUSSION
+            > One-sentence overall assessment.
+            ```
+
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://docs.anthropic.com/en/docs/claude-code/sdk#command-line for available options
-          claude_args: '--allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'
-
+          claude_args: '--allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(gh api:*)"'


### PR DESCRIPTION
# Pull Request

## Description
Rework the `Claude Code Review` GitHub Action to submit **one** PR review with per-line inline comments (severity-tagged 🔴 CRITICAL / 🟡 SUGGESTION / 🔵 QUESTION) plus a structured summary body — instead of posting one monolithic PR comment.

This mirrors the flow already defined in `.claude/commands/review_pr.md` so local `/review_pr` invocations and the automated CI review produce the same shape of feedback.

### What changed

- **Prompt rewritten** — review criteria, inline-comment schema, event-selection rule, and summary-body template.
- **Single API call for submission** — `gh api POST /repos/.../pulls/.../reviews` with `commits[]`, `body`, and `event`, so the review is atomic and carries a verdict.
- **Removed redundant context-fetching** — `claude-code-action` already injects PR title/body/diff/changed files; dropped the `gh pr view` / `gh pr diff` steps and use `${{ github.repository }}` + `${{ github.event.pull_request.head.sha }}` directly.
- **Permissions** — `pull-requests: read` → `write` (required to POST a review).
- **Allowlist** — added `Bash(gh api:*)` to `claude_args`; added `Bash(git checkout -b *)` to local settings.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Code quality improvement
- [x] Configuration change

## Testing
- [ ] Tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested integration scenarios if applicable

_N/A — CI workflow change. Validation will happen on the next PR where the workflow runs; the review body / inline comments / verdict should appear as one GitHub review rather than a plain comment._

## Code Quality
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have made corresponding changes to the documentation if needed
- [x] Pre-commit hooks pass (run `pre-commit run --all-files`)
- [x] Ruff linting passes (`ruff check src/ tests/`)
- [x] Ruff formatting passes (`ruff format src/ tests/ --check`)

## Related Issues
N/A

## Additional Notes
- The workflow now requires `pull-requests: write`. If branch-protection rules limit what the `GITHUB_TOKEN` can do from forked PRs, reviews on fork PRs may need to run with `pull_request_target` (not changed here — scoped intentionally).
- Only `Bash(gh api:*)` is needed for the new flow; the older `gh pr comment` entry is retained in the allowlist for backward compatibility with any other prompts in the repo.

---

**Checklist for Reviewers:**
- [ ] Code follows project conventions and style guidelines
- [ ] Changes are well-tested with appropriate test coverage
- [ ] Documentation is updated if necessary
- [ ] Security implications have been considered (note: `pull-requests: write` scope)
- [ ] Performance implications have been considered

🤖 Generated with [Claude Code](https://claude.com/claude-code)