### PR TITLE
✨ feat(api): add export-openapi recipe using Litestar's native CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,9 @@ coverage.xml
 # Load test reports
 src/presentation/load_test/reports/
 
+# Generated OpenAPI schema (run `just export-openapi`)
+openapi.json
+
 # Git worktrees
 .worktrees/
 

--- a/justfile
+++ b/justfile
@@ -69,3 +69,7 @@ lint:
 generate-i18n:
     uv run python scripts/generate_i18n_stubs.py
     uv run ruff format src/infrastructure/i18n/types.py
+
+# Export the API OpenAPI schema to a JSON file (default: openapi.json)
+export-openapi output="openapi.json":
+    LITESTAR_APP=src.presentation.api.app:create_app uv run litestar schema openapi --output {{output}}


### PR DESCRIPTION
## Description
Adds a `just export-openapi [output]` recipe that dumps the API's OpenAPI schema to JSON (default: `openapi.json`).

It uses Litestar's **built-in** `litestar schema openapi` CLI instead of a hand-rolled export script. An earlier draft of this branch added a 41-line `scripts/export_openapi.py`; review found Litestar already ships this exact capability, producing byte-identical output. The script was dropped in favour of the native command — less code to maintain, and the export stays in lockstep with how the app is built.

The generated `openapi.json` is gitignored since it's a build artifact produced on demand.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Code quality improvement
- [ ] Configuration change

## Testing
- [x] Tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested integration scenarios if applicable

Verified manually: `just export-openapi /tmp/openapi.json` exits 0 and emits a 3-path schema, byte-identical to the previous script's output. No automated test added — this is a thin wrapper around a vendored CLI command.

## Code Quality
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have made corresponding changes to the documentation if needed
- [x] Pre-commit hooks pass (run `pre-commit run --all-files`)
- [x] Ruff linting passes (`ruff check src/ tests/`)
- [x] Ruff formatting passes (`ruff format src/ tests/ --check`)

## Related Issues
N/A

## Additional Notes
No new dependency added — `litestar` is already a direct dependency. The recipe sets `LITESTAR_APP=src.presentation.api.app:create_app` so the CLI can discover the app factory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
